### PR TITLE
Improvements to Maho's autoloaders

### DIFF
--- a/src/MahoAutoload.php
+++ b/src/MahoAutoload.php
@@ -7,6 +7,7 @@ use Composer\InstalledVersions;
 class MahoAutoload
 {
     protected static $modules = null;
+    protected static $canUseLocalModules = null;
     protected static $paths = null;
 
     public static function getInstalledModules(string $projectDir): array
@@ -45,12 +46,35 @@ class MahoAutoload
         return self::$modules;
     }
 
+    public static function canUseLocalModules(string $projectDir): bool
+    {
+        if (self::$canUseLocalModules !== null) {
+            return self::$canUseLocalModules;
+        }
+        self::$canUseLocalModules = true;
+
+        try {
+            $config = simplexml_load_file("$projectDir/app/etc/local.xml");
+            if ($config) {
+                $disable = $config->global->disable_local_modules;
+                if ($disable === 'true' || $disable === '1') {
+                    self::$canUseLocalModules = false;
+                }
+            }
+        } catch (Throwable) {
+        }
+
+        return self::$canUseLocalModules;
+    }
+
     public static function generatePaths(string $projectDir): array
     {
         if (self::$paths !== null) {
             return self::$paths;
         }
         self::$paths = [];
+
+        self::canUseLocalModules($projectDir);
 
         $modules = self::getInstalledModules($projectDir);
 
@@ -67,7 +91,10 @@ class MahoAutoload
             }
         };
 
-        $addIfExists($projectDir, 'app/code/local');
+        if (self::canUseLocalModules($projectDir)) {
+            $addIfExists($projectDir, 'app/code/local');
+        }
+
         $addIfExists($projectDir, 'app/code/community');
 
         if ($modules['mahocommerce/maho']['isChildProject']) {

--- a/src/MahoAutoload.php
+++ b/src/MahoAutoload.php
@@ -133,7 +133,9 @@ class MahoAutoload
                     $classname = substr($file->getPathname(), strlen($path) + 1, -4);
                     $classname = str_replace('/controllers/', '/', $classname);
                     $classname = str_replace('/', '_', $classname);
-                    $classmaps[$classname] = $file->getPathname();
+                    if (!isset($classmaps[$classname])) {
+                        $classmaps[$classname] = $file->getPathname();
+                    }
                  }
             }
         }

--- a/src/MahoAutoload.php
+++ b/src/MahoAutoload.php
@@ -117,4 +117,27 @@ class MahoAutoload
 
         return $prefixes;
     }
+
+    public static function generateControllerClassMap(string $projectDir): array
+    {
+        $paths = self::generatePaths($projectDir);
+
+        $classmaps = [];
+        foreach ($paths as $path) {
+            foreach (glob("$path/*/*/controllers", GLOB_ONLYDIR) as $dir) {
+                $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+                foreach ($files as $file) {
+                    if (!$file->isFile() || !str_ends_with($file->getFileName(), 'Controller.php')) {
+                        continue;
+                    }
+                    $classname = substr($file->getPathname(), strlen($path) + 1, -4);
+                    $classname = str_replace('/controllers/', '/', $classname);
+                    $classname = str_replace('/', '_', $classname);
+                    $classmaps[$classname] = $file->getPathname();
+                 }
+            }
+        }
+
+        return $classmaps;
+    }
 }

--- a/src/MahoAutoload.php
+++ b/src/MahoAutoload.php
@@ -7,7 +7,6 @@ use Composer\InstalledVersions;
 class MahoAutoload
 {
     protected static $modules = null;
-    protected static $canUseLocalModules = null;
     protected static $paths = null;
 
     public static function getInstalledModules(string $projectDir): array
@@ -46,35 +45,12 @@ class MahoAutoload
         return self::$modules;
     }
 
-    public static function canUseLocalModules(string $projectDir): bool
-    {
-        if (self::$canUseLocalModules !== null) {
-            return self::$canUseLocalModules;
-        }
-        self::$canUseLocalModules = true;
-
-        try {
-            $config = simplexml_load_file("$projectDir/app/etc/local.xml");
-            if ($config) {
-                $disable = $config->global->disable_local_modules;
-                if ($disable === 'true' || $disable === '1') {
-                    self::$canUseLocalModules = false;
-                }
-            }
-        } catch (Throwable) {
-        }
-
-        return self::$canUseLocalModules;
-    }
-
     public static function generatePaths(string $projectDir): array
     {
         if (self::$paths !== null) {
             return self::$paths;
         }
         self::$paths = [];
-
-        self::canUseLocalModules($projectDir);
 
         $modules = self::getInstalledModules($projectDir);
 
@@ -91,10 +67,7 @@ class MahoAutoload
             }
         };
 
-        if (self::canUseLocalModules($projectDir)) {
-            $addIfExists($projectDir, 'app/code/local');
-        }
-
+        $addIfExists($projectDir, 'app/code/local');
         $addIfExists($projectDir, 'app/code/community');
 
         if ($modules['mahocommerce/maho']['isChildProject']) {

--- a/src/MahoAutoload.php
+++ b/src/MahoAutoload.php
@@ -7,6 +7,7 @@ use Composer\InstalledVersions;
 class MahoAutoload
 {
     protected static $modules = null;
+    protected static $paths = null;
 
     public static function getInstalledModules(string $projectDir): array
     {
@@ -46,6 +47,11 @@ class MahoAutoload
 
     public static function generatePaths(string $projectDir): array
     {
+        if (self::$paths !== null) {
+            return self::$paths;
+        }
+        self::$paths = [];
+
         $modules = self::getInstalledModules($projectDir);
 
         $codePools = [
@@ -86,7 +92,7 @@ class MahoAutoload
             $addIfExists($projectDir, 'lib');
         }
 
-        return array_merge(...array_values($codePools));
+        return self::$paths = array_merge(...array_values($codePools));
     }
 
     public static function generatePsr0(string $projectDir): array

--- a/src/MahoAutoload.php
+++ b/src/MahoAutoload.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Maho;
+
+use Composer\InstalledVersions;
+
+class MahoAutoload
+{
+    protected static $modules = null;
+
+    public static function getInstalledModules(): array
+    {
+        if (self::$modules !== null) {
+            return self::$modules;
+        }
+        self::$modules = [];
+
+        $datasets = InstalledVersions::getAllRawData();
+        $dataset = end($datasets); // We only care about the packages installed to root vendor dir
+
+        foreach ($dataset['versions'] as $package => $info) {
+            if (!isset($info['install_path'])) {
+                continue;
+            }
+            if (!in_array($info['type'], ['maho-source', 'maho-module', 'magento-module'])) {
+                continue;
+            }
+            $module = [
+                'type' => $info['type'],
+                'path' => realpath($info['install_path']),
+            ];
+            if ($package === 'mahocommerce/maho') {
+                self::$modules = [$package => $module] + self::$modules;
+            } else {
+                self::$modules[$package] = $module;
+            }
+        }
+
+        return self::$modules;
+    }
+
+    public static function generatePaths(string $BP): array
+    {
+        $datasets = InstalledVersions::getAllRawData();
+        $dataset = end($datasets); // We only care about the packages installed to root vendor dir
+
+        $MAHO_IS_CHILD_PROJECT = $dataset['root']['name'] !== 'mahocommerce/maho';
+        $MAHO_FRAMEWORK_DIR = realpath($dataset['versions']['mahocommerce/maho']['install_path']);
+
+        $codePools = [
+            'app/code/local' => [],
+            'app/code/community' => [],
+            'app/code/core' => [],
+            'lib' => [],
+        ];
+
+        $addIfExists = function ($path, $codePool) use (&$codePools) {
+            if (is_dir("$path/$codePool")) {
+                $codePools[$codePool][] = "$path/$codePool";
+            }
+        };
+
+        $addIfExists($BP, 'app/code/local');
+        $addIfExists($BP, 'app/code/community');
+        if ($MAHO_IS_CHILD_PROJECT) {
+            $addIfExists($BP, 'app/code/core');
+            $addIfExists($BP, 'lib');
+        }
+
+        foreach (self::getInstalledModules() as $module => $info) {
+            if ($module === 'mahocommerce/maho') {
+                continue;
+            }
+            $path = $info['path'];
+            foreach (array_keys($codePools) as $codePool) {
+                $addIfExists($path, $codePool);
+            }
+        }
+
+        if ($MAHO_IS_CHILD_PROJECT) {
+            $addIfExists($MAHO_FRAMEWORK_DIR, 'app/code/core');
+            $addIfExists($MAHO_FRAMEWORK_DIR, 'lib');
+        } else {
+            $addIfExists($BP, 'app/code/core');
+            $addIfExists($BP, 'lib');
+        }
+
+        return array_merge(...array_values($codePools));
+    }
+
+    public static function generatePsr0(string $BP): array
+    {
+        $paths = self::generatePaths($BP);
+
+        $prefixes = [];
+        foreach ($paths as $path) {
+            foreach (glob("$path/*/*") as $file) {
+                $prefix = str_replace('/', '_', substr($file, strlen($path) + 1));
+                if (is_file($file) && str_ends_with($file, '.php')) {
+                    $prefix = str_replace('.php', '', $prefix);
+                } else if (is_dir($file)) {
+                    $prefix .= '_';
+                } else {
+                    continue;
+                }
+                $prefixes[$prefix] ??= [];
+                $prefixes[$prefix][] = $path;
+            }
+        }
+
+        return $prefixes;
+    }
+}

--- a/src/MahoComposerPlugin.php
+++ b/src/MahoComposerPlugin.php
@@ -87,6 +87,10 @@ class MahoComposerPlugin implements PluginInterface, EventSubscriberInterface
                 $autoloadDefinition['psr-0'][$prefix] ??= [];
                 array_push($autoloadDefinition['psr-0'][$prefix], ...$paths);
             }
+
+            $classMap = MahoAutoload::generateControllerClassMap($projectDir);
+            $autoloadDefinition['classmap'] ??= [];
+            array_push($autoloadDefinition['classmap'], ...array_values($classMap));
         }
 
         $rootPackage->setAutoload($autoloadDefinition);

--- a/src/MahoComposerPlugin.php
+++ b/src/MahoComposerPlugin.php
@@ -33,7 +33,8 @@ class MahoComposerPlugin implements PluginInterface, EventSubscriberInterface
         return [
             ScriptEvents::POST_INSTALL_CMD => 'onPostCmd',
             ScriptEvents::POST_UPDATE_CMD => 'onPostCmd',
-            ScriptEvents::POST_CREATE_PROJECT_CMD => 'onPostCmd'
+            ScriptEvents::POST_CREATE_PROJECT_CMD => 'onPostCmd',
+            ScriptEvents::PRE_AUTOLOAD_DUMP => 'onPreAutoloadDumpCmd',
         ];
     }
 
@@ -65,6 +66,30 @@ class MahoComposerPlugin implements PluginInterface, EventSubscriberInterface
         if (file_exists("$vendorDir/mklkj/tinymce-i18n/langs6")) {
             $this->copyDirectory("$vendorDir/mklkj/tinymce-i18n/langs6", "$projectDir/public/js/tinymce/langs", $io);
         }
+    }
+
+    public function onPreAutoloadDumpCmd($event): void
+    {
+        $projectDir = getcwd();
+
+        $composer = $event->getComposer();
+        $rootPackage = $composer->getPackage();
+        $autoloadDefinition = $rootPackage->getAutoload();
+
+        if ($event->getFlags()['optimize']) {
+            $paths = MahoAutoload::generatePaths($projectDir);
+            $autoloadDefinition['classmap'] ??= [];
+            array_push($autoloadDefinition['classmap'], ...$paths);
+        } else {
+            $psr0 = MahoAutoload::generatePsr0($projectDir);
+            $autoloadDefinition['psr-0'] ??= [];
+            foreach ($psr0 as $prefix => $paths) {
+                $autoloadDefinition['psr-0'][$prefix] ??= [];
+                array_push($autoloadDefinition['psr-0'][$prefix], ...$paths);
+            }
+        }
+
+        $rootPackage->setAutoload($autoloadDefinition);
     }
 
     private function copyDirectory($src, $dst, $io)


### PR DESCRIPTION
See https://github.com/MahoCommerce/maho/pull/40#issuecomment-2400987038

We hook into the dump event and build PSR-0 prefixes, as well as classmaps for controllers which do not follow PSR-0 naming convention.

We also need to read local.xml to check if we have disabled local modules, as we must exclude those from our prefixes / classmaps. It would be too messy to try to do that at runtime.