### PR TITLE
Add PHP attribute compiler for observer and cron job registration

### DIFF
--- a/.phpstan.dist.neon
+++ b/.phpstan.dist.neon
@@ -10,3 +10,5 @@ parameters:
     paths:
         - src
     level: 10
+    scanFiles:
+        - stubs/MahoAttributes.stub

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -1,0 +1,232 @@
+<?php declare(strict_types=1);
+
+namespace Maho\ComposerPlugin;
+
+use Maho\Attributes\CronJob;
+use Maho\Attributes\Observer;
+use ReflectionClass;
+use ReflectionMethod;
+
+class AttributeCompiler
+{
+    private const SCAN_PATTERNS = [
+        '/app/code/*/*/*/Model/*.php',
+        '/app/code/*/*/*/Helper/*.php',
+        '/app/code/*/*/*/Block/*.php',
+    ];
+
+    /**
+     * Compile PHP attributes into a cached array file.
+     *
+     * @param string $outputDir Directory where attributes.php will be written
+     */
+    public static function compile(string $outputDir): void
+    {
+        $data = [
+            'observers' => [
+                'global' => [],
+                'frontend' => [],
+                'adminhtml' => [],
+            ],
+            'crontab' => [],
+        ];
+
+        $replaces = [];
+
+        foreach (self::scanFiles() as $file) {
+            $contents = file_get_contents($file);
+            if ($contents === false) {
+                continue;
+            }
+
+            if (strpos($contents, 'Maho\Attributes\Observer') === false && strpos($contents, 'Maho\Attributes\CronJob') === false) {
+                continue;
+            }
+
+            $className = self::extractClassName($contents);
+            if ($className === null) {
+                continue;
+            }
+
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+                continue;
+            }
+
+            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->getDeclaringClass()->getName() !== $className) {
+                    continue;
+                }
+
+                self::processObserverAttributes($method, $className, $data, $replaces);
+                self::processCronJobAttributes($method, $className, $data);
+            }
+        }
+
+        self::applyReplaces($data, $replaces);
+        self::writeOutput($outputDir, $data);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function scanFiles(): array
+    {
+        $files = [];
+        foreach (self::SCAN_PATTERNS as $pattern) {
+            array_push($files, ...AutoloadRuntime::globPackages($pattern));
+        }
+        return array_values(array_unique($files));
+    }
+
+    private static function extractClassName(string $contents): ?string
+    {
+        if (!preg_match('/^class\s+(\w+)/m', $contents, $classMatch)) {
+            return null;
+        }
+
+        $className = $classMatch[1];
+
+        if (preg_match('/^namespace\s+([^\s;]+)/m', $contents, $nsMatch)) {
+            $className = $nsMatch[1] . '\\' . $className;
+        }
+
+        return $className;
+    }
+
+    /**
+     * @param array<string, array<string, array<string, list<array<string, mixed>>>>> $data
+     * @param list<array{target: string, area: string, event: string}> $replaces
+     */
+    private static function processObserverAttributes(
+        ReflectionMethod $method,
+        string $className,
+        array &$data,
+        array &$replaces,
+    ): void {
+        $attributes = $method->getAttributes(Observer::class);
+        foreach ($attributes as $attribute) {
+            $observer = $attribute->newInstance();
+            $name = $observer->name ?? $className . '::' . $method->getName();
+            $areas = array_map('trim', explode(',', $observer->area));
+            $event = strtolower($observer->event);
+
+            $entry = [
+                'name' => $name,
+                'module' => self::extractModuleName($className),
+                'class' => $className,
+                'method' => $method->getName(),
+                'type' => $observer->type,
+                'args' => $observer->args,
+            ];
+
+            foreach ($areas as $area) {
+                $data['observers'][$area][$event] ??= [];
+                $data['observers'][$area][$event][] = $entry;
+
+                if ($observer->replaces !== null) {
+                    $replaces[] = [
+                        'target' => $observer->replaces,
+                        'area' => $area,
+                        'event' => $event,
+                    ];
+                }
+            }
+        }
+    }
+
+    private static function processCronJobAttributes(
+        ReflectionMethod $method,
+        string $className,
+        array &$data,
+    ): void {
+        $attributes = $method->getAttributes(CronJob::class);
+        foreach ($attributes as $attribute) {
+            $cronJob = $attribute->newInstance();
+            $name = $cronJob->name ?? self::generateCronJobName($className, $method->getName());
+
+            $data['crontab'][$name] = [
+                'class' => $className,
+                'method' => $method->getName(),
+                'schedule' => $cronJob->schedule,
+                'config_path' => $cronJob->configPath,
+            ];
+        }
+    }
+
+    private static function generateCronJobName(string $className, string $methodName): string
+    {
+        $prefix = preg_replace('/^Mage_/', '', $className);
+        $prefix = preg_replace('/_Model_/', '_', $prefix);
+        $prefix = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $prefix));
+        $method = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $methodName));
+        return $prefix . '_' . $method;
+    }
+
+    /**
+     * Remove observers targeted by `replaces` directives.
+     *
+     * Only resolves attribute→attribute replaces at compile time.
+     * Attribute→XML replaces are stored in the compiled output and resolved at runtime.
+     */
+    private static function applyReplaces(array &$data, array $replaces): void
+    {
+        $unresolvedReplaces = [];
+
+        foreach ($replaces as $replace) {
+            $resolved = false;
+            $area = $replace['area'];
+            $event = $replace['event'];
+            $target = $replace['target'];
+
+            if (isset($data['observers'][$area][$event])) {
+                foreach ($data['observers'][$area][$event] as $key => $observer) {
+                    if ($observer['name'] === $target) {
+                        unset($data['observers'][$area][$event][$key]);
+                        $data['observers'][$area][$event] = array_values($data['observers'][$area][$event]);
+                        $resolved = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!$resolved) {
+                $unresolvedReplaces[] = $replace;
+            }
+        }
+
+        // Store unresolved replaces for runtime resolution against XML observers
+        if ($unresolvedReplaces) {
+            $data['replaces'] = $unresolvedReplaces;
+        }
+    }
+
+    private static function extractModuleName(string $className): string
+    {
+        // Mage_Wishlist_Model_Observer → Mage_Wishlist
+        // Mage_CatalogInventory_Model_Observer → Mage_CatalogInventory
+        if (preg_match('/^(Mage_[A-Za-z]+)_/', $className, $matches)) {
+            return $matches[1];
+        }
+        // Maho\SomeModule\... → derive from namespace
+        if (preg_match('/^(Maho\\\\[A-Za-z]+)\\\\/', $className, $matches)) {
+            return $matches[1];
+        }
+        return $className;
+    }
+
+    private static function writeOutput(string $outputDir, array $data): void
+    {
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $content = '<?php return ' . var_export($data, true) . ";\n";
+        file_put_contents($outputDir . '/attributes.php', $content);
+    }
+}

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -16,13 +16,22 @@ class AttributeCompiler
     ];
 
     /**
+     * @var array{
+     *     observers: array<string, array<string, list<array{name: string, module: string, class: string, method: string, type: string, args: array<string, mixed>}>>>,
+     *     crontab: array<string, array{class: string, method: string, schedule: ?string, config_path: ?string}>,
+     *     replaces?: list<array{target: string, area: string, event: string}>
+     * }
+     */
+    private static array $data;
+
+    /**
      * Compile PHP attributes into a cached array file.
      *
      * @param string $outputDir Directory where attributes.php will be written
      */
     public static function compile(string $outputDir): void
     {
-        $data = [
+        self::$data = [
             'observers' => [
                 'global' => [],
                 'frontend' => [],
@@ -63,13 +72,13 @@ class AttributeCompiler
                     continue;
                 }
 
-                self::processObserverAttributes($method, $className, $data, $replaces);
-                self::processCronJobAttributes($method, $className, $data);
+                self::processObserverAttributes($method, $className, $replaces);
+                self::processCronJobAttributes($method, $className);
             }
         }
 
-        self::applyReplaces($data, $replaces);
-        self::writeOutput($outputDir, $data);
+        self::applyReplaces($replaces);
+        self::writeOutput($outputDir);
     }
 
     /**
@@ -86,13 +95,13 @@ class AttributeCompiler
 
     private static function extractClassName(string $contents): ?string
     {
-        if (!preg_match('/^class\s+(\w+)/m', $contents, $classMatch)) {
+        if (preg_match('/^(?:final\s+|readonly\s+|abstract\s+)*class\s+(\w+)/m', $contents, $classMatch) !== 1) {
             return null;
         }
 
         $className = $classMatch[1];
 
-        if (preg_match('/^namespace\s+([^\s;]+)/m', $contents, $nsMatch)) {
+        if (preg_match('/^namespace\s+([^\s;]+)/m', $contents, $nsMatch) === 1) {
             $className = $nsMatch[1] . '\\' . $className;
         }
 
@@ -100,13 +109,11 @@ class AttributeCompiler
     }
 
     /**
-     * @param array<string, array<string, array<string, list<array<string, mixed>>>>> $data
      * @param list<array{target: string, area: string, event: string}> $replaces
      */
     private static function processObserverAttributes(
         ReflectionMethod $method,
         string $className,
-        array &$data,
         array &$replaces,
     ): void {
         $attributes = $method->getAttributes(Observer::class);
@@ -126,8 +133,8 @@ class AttributeCompiler
             ];
 
             foreach ($areas as $area) {
-                $data['observers'][$area][$event] ??= [];
-                $data['observers'][$area][$event][] = $entry;
+                self::$data['observers'][$area][$event] ??= [];
+                self::$data['observers'][$area][$event][] = $entry;
 
                 if ($observer->replaces !== null) {
                     $replaces[] = [
@@ -143,14 +150,13 @@ class AttributeCompiler
     private static function processCronJobAttributes(
         ReflectionMethod $method,
         string $className,
-        array &$data,
     ): void {
         $attributes = $method->getAttributes(CronJob::class);
         foreach ($attributes as $attribute) {
             $cronJob = $attribute->newInstance();
             $name = $cronJob->name ?? self::generateCronJobName($className, $method->getName());
 
-            $data['crontab'][$name] = [
+            self::$data['crontab'][$name] = [
                 'class' => $className,
                 'method' => $method->getName(),
                 'schedule' => $cronJob->schedule,
@@ -161,10 +167,10 @@ class AttributeCompiler
 
     private static function generateCronJobName(string $className, string $methodName): string
     {
-        $prefix = preg_replace('/^Mage_/', '', $className);
-        $prefix = preg_replace('/_Model_/', '_', $prefix);
-        $prefix = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $prefix));
-        $method = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $methodName));
+        $prefix = (string) preg_replace('/^Mage_/', '', $className);
+        $prefix = (string) preg_replace('/_Model_/', '_', $prefix);
+        $prefix = strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1_$2', $prefix));
+        $method = strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1_$2', $methodName));
         return $prefix . '_' . $method;
     }
 
@@ -173,8 +179,10 @@ class AttributeCompiler
      *
      * Only resolves attribute→attribute replaces at compile time.
      * Attribute→XML replaces are stored in the compiled output and resolved at runtime.
+     *
+     * @param list<array{target: string, area: string, event: string}> $replaces
      */
-    private static function applyReplaces(array &$data, array $replaces): void
+    private static function applyReplaces(array $replaces): void
     {
         $unresolvedReplaces = [];
 
@@ -184,15 +192,17 @@ class AttributeCompiler
             $event = $replace['event'];
             $target = $replace['target'];
 
-            if (isset($data['observers'][$area][$event])) {
-                foreach ($data['observers'][$area][$event] as $key => $observer) {
-                    if ($observer['name'] === $target) {
-                        unset($data['observers'][$area][$event][$key]);
-                        $data['observers'][$area][$event] = array_values($data['observers'][$area][$event]);
-                        $resolved = true;
-                        break;
-                    }
-                }
+            if (isset(self::$data['observers'][$area][$event])) {
+                $observers = self::$data['observers'][$area][$event];
+                $countBefore = count($observers);
+                $observers = array_values(
+                    array_filter(
+                        $observers,
+                        static fn (array $observer): bool => $observer['name'] !== $target,
+                    ),
+                );
+                self::$data['observers'][$area][$event] = $observers;
+                $resolved = count($observers) < $countBefore;
             }
 
             if (!$resolved) {
@@ -201,8 +211,8 @@ class AttributeCompiler
         }
 
         // Store unresolved replaces for runtime resolution against XML observers
-        if ($unresolvedReplaces) {
-            $data['replaces'] = $unresolvedReplaces;
+        if ($unresolvedReplaces !== []) {
+            self::$data['replaces'] = $unresolvedReplaces;
         }
     }
 
@@ -210,23 +220,23 @@ class AttributeCompiler
     {
         // Mage_Wishlist_Model_Observer → Mage_Wishlist
         // Mage_CatalogInventory_Model_Observer → Mage_CatalogInventory
-        if (preg_match('/^(Mage_[A-Za-z]+)_/', $className, $matches)) {
+        if (preg_match('/^(Mage_[A-Za-z]+)_/', $className, $matches) === 1) {
             return $matches[1];
         }
         // Maho\SomeModule\... → derive from namespace
-        if (preg_match('/^(Maho\\\\[A-Za-z]+)\\\\/', $className, $matches)) {
+        if (preg_match('/^(Maho\\\\[A-Za-z]+)\\\\/', $className, $matches) === 1) {
             return $matches[1];
         }
         return $className;
     }
 
-    private static function writeOutput(string $outputDir, array $data): void
+    private static function writeOutput(string $outputDir): void
     {
         if (!is_dir($outputDir)) {
             mkdir($outputDir, 0755, true);
         }
 
-        $content = '<?php return ' . var_export($data, true) . ";\n";
+        $content = '<?php return ' . var_export(self::$data, true) . ";\n";
         file_put_contents($outputDir . '/attributes.php', $content);
     }
 }

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -2,18 +2,18 @@
 
 namespace Maho\ComposerPlugin;
 
+use Composer\ClassMapGenerator\ClassMapGenerator;
+use Composer\IO\IOInterface;
 use Maho\Attributes\CronJob;
 use Maho\Attributes\Observer;
 use ReflectionClass;
 use ReflectionMethod;
 
-class AttributeCompiler
+final class AttributeCompiler
 {
-    private const SCAN_PATTERNS = [
-        '/app/code/*/*/*/Model/*.php',
-        '/app/code/*/*/*/Helper/*.php',
-        '/app/code/*/*/*/Block/*.php',
-    ];
+    private const SCAN_DIRS = ['Model', 'Helper', 'Block'];
+
+    private const ALLOWED_AREAS = ['global', 'frontend', 'adminhtml'];
 
     /**
      * @var array{
@@ -29,7 +29,7 @@ class AttributeCompiler
      *
      * @param string $outputDir Directory where attributes.php will be written
      */
-    public static function compile(string $outputDir): void
+    public static function compile(string $outputDir, IOInterface $io): void
     {
         self::$data = [
             'observers' => [
@@ -42,18 +42,13 @@ class AttributeCompiler
 
         $replaces = [];
 
-        foreach (self::scanFiles() as $file) {
-            $contents = file_get_contents($file);
+        foreach (self::scanClasses() as $className => $filePath) {
+            $contents = file_get_contents($filePath);
             if ($contents === false) {
                 continue;
             }
 
             if (strpos($contents, 'Maho\Attributes\Observer') === false && strpos($contents, 'Maho\Attributes\CronJob') === false) {
-                continue;
-            }
-
-            $className = self::extractClassName($contents);
-            if ($className === null) {
                 continue;
             }
 
@@ -72,8 +67,8 @@ class AttributeCompiler
                     continue;
                 }
 
-                self::processObserverAttributes($method, $className, $replaces);
-                self::processCronJobAttributes($method, $className);
+                self::processObserverAttributes($method, $className, $replaces, $io);
+                self::processCronJobAttributes($method, $className, $io);
             }
         }
 
@@ -82,30 +77,24 @@ class AttributeCompiler
     }
 
     /**
-     * @return list<string>
+     * Scan all module directories for PHP classes using Composer's ClassMapGenerator.
+     *
+     * @return array<class-string, string>
      */
-    private static function scanFiles(): array
+    private static function scanClasses(): array
     {
-        $files = [];
-        foreach (self::SCAN_PATTERNS as $pattern) {
-            array_push($files, ...AutoloadRuntime::globPackages($pattern));
-        }
-        return array_values(array_unique($files));
-    }
+        $classes = [];
 
-    private static function extractClassName(string $contents): ?string
-    {
-        if (preg_match('/^(?:final\s+|readonly\s+|abstract\s+)*class\s+(\w+)/m', $contents, $classMatch) !== 1) {
-            return null;
+        foreach (AutoloadRuntime::globPackages('/app/code/*/*/*', GLOB_ONLYDIR) as $moduleDir) {
+            foreach (self::SCAN_DIRS as $subDir) {
+                $dir = $moduleDir . '/' . $subDir;
+                if (is_dir($dir)) {
+                    $classes += ClassMapGenerator::createMap($dir);
+                }
+            }
         }
 
-        $className = $classMatch[1];
-
-        if (preg_match('/^namespace\s+([^\s;]+)/m', $contents, $nsMatch) === 1) {
-            $className = $nsMatch[1] . '\\' . $className;
-        }
-
-        return $className;
+        return $classes;
     }
 
     /**
@@ -115,10 +104,22 @@ class AttributeCompiler
         ReflectionMethod $method,
         string $className,
         array &$replaces,
+        IOInterface $io,
     ): void {
         $attributes = $method->getAttributes(Observer::class);
         foreach ($attributes as $attribute) {
-            $observer = $attribute->newInstance();
+            try {
+                $observer = $attribute->newInstance();
+            } catch (\Throwable $e) {
+                $io->writeError(sprintf(
+                    '  <warning>Skipping Observer attribute on %s::%s: %s</warning>',
+                    $className,
+                    $method->getName(),
+                    $e->getMessage(),
+                ));
+                continue;
+            }
+
             $name = $observer->name ?? $className . '::' . $method->getName();
             $areas = array_map('trim', explode(',', $observer->area));
             $event = strtolower($observer->event);
@@ -133,6 +134,16 @@ class AttributeCompiler
             ];
 
             foreach ($areas as $area) {
+                if (!in_array($area, self::ALLOWED_AREAS, true)) {
+                    $io->writeError(sprintf(
+                        '  <warning>Invalid observer area "%s" on %s::%s, skipping</warning>',
+                        $area,
+                        $className,
+                        $method->getName(),
+                    ));
+                    continue;
+                }
+
                 self::$data['observers'][$area][$event] ??= [];
                 self::$data['observers'][$area][$event][] = $entry;
 
@@ -150,10 +161,22 @@ class AttributeCompiler
     private static function processCronJobAttributes(
         ReflectionMethod $method,
         string $className,
+        IOInterface $io,
     ): void {
         $attributes = $method->getAttributes(CronJob::class);
         foreach ($attributes as $attribute) {
-            $cronJob = $attribute->newInstance();
+            try {
+                $cronJob = $attribute->newInstance();
+            } catch (\Throwable $e) {
+                $io->writeError(sprintf(
+                    '  <warning>Skipping CronJob attribute on %s::%s: %s</warning>',
+                    $className,
+                    $method->getName(),
+                    $e->getMessage(),
+                ));
+                continue;
+            }
+
             $name = $cronJob->name ?? self::generateCronJobName($className, $method->getName());
 
             self::$data['crontab'][$name] = [
@@ -167,11 +190,28 @@ class AttributeCompiler
 
     private static function generateCronJobName(string $className, string $methodName): string
     {
-        $prefix = (string) preg_replace('/^Mage_/', '', $className);
-        $prefix = (string) preg_replace('/_Model_/', '_', $prefix);
-        $prefix = strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1_$2', $prefix));
-        $method = strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1_$2', $methodName));
+        $prefix = $className;
+        if (str_starts_with($prefix, 'Mage_')) {
+            $prefix = substr($prefix, 5);
+        }
+        $prefix = str_replace('_Model_', '_', $prefix);
+        $prefix = strtolower(self::camelToSnake($prefix));
+        $method = strtolower(self::camelToSnake($methodName));
         return $prefix . '_' . $method;
+    }
+
+    private static function camelToSnake(string $input): string
+    {
+        $result = '';
+        $length = strlen($input);
+        for ($i = 0; $i < $length; $i++) {
+            $char = $input[$i];
+            if ($i > 0 && ctype_upper($char) && ctype_lower($input[$i - 1])) {
+                $result .= '_';
+            }
+            $result .= $char;
+        }
+        return $result;
     }
 
     /**
@@ -218,15 +258,21 @@ class AttributeCompiler
 
     private static function extractModuleName(string $className): string
     {
-        // Mage_Wishlist_Model_Observer → Mage_Wishlist
-        // Mage_CatalogInventory_Model_Observer → Mage_CatalogInventory
-        if (preg_match('/^(Mage_[A-Za-z]+)_/', $className, $matches) === 1) {
-            return $matches[1];
+        // Namespace-style: Maho\SomeModule\..., Vendor\Module\... → first two segments
+        if (str_contains($className, '\\')) {
+            $parts = explode('\\', $className);
+            if (count($parts) >= 2) {
+                return $parts[0] . '\\' . $parts[1];
+            }
+            return $className;
         }
-        // Maho\SomeModule\... → derive from namespace
-        if (preg_match('/^(Maho\\\\[A-Za-z]+)\\\\/', $className, $matches) === 1) {
-            return $matches[1];
+
+        // Underscore-style: Mage_Wishlist_Model_Observer, Vendor_Module_... → first two segments
+        $parts = explode('_', $className);
+        if (count($parts) >= 2) {
+            return $parts[0] . '_' . $parts[1];
         }
+
         return $className;
     }
 

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -11,9 +11,7 @@ use ReflectionMethod;
 
 final class AttributeCompiler
 {
-    private const SCAN_DIRS = ['Model', 'Helper', 'Block'];
-
-    private const ALLOWED_AREAS = ['global', 'frontend', 'adminhtml'];
+    private const ALLOWED_AREAS = ['global', 'frontend', 'adminhtml', 'crontab'];
 
     /**
      * @var array{
@@ -36,6 +34,7 @@ final class AttributeCompiler
                 'global' => [],
                 'frontend' => [],
                 'adminhtml' => [],
+                'crontab' => [],
             ],
             'crontab' => [],
         ];
@@ -73,7 +72,7 @@ final class AttributeCompiler
         }
 
         self::applyReplaces($replaces);
-        self::writeOutput($outputDir);
+        self::writeOutput($outputDir, $io);
     }
 
     /**
@@ -86,12 +85,7 @@ final class AttributeCompiler
         $classes = [];
 
         foreach (AutoloadRuntime::globPackages('/app/code/*/*/*', GLOB_ONLYDIR) as $moduleDir) {
-            foreach (self::SCAN_DIRS as $subDir) {
-                $dir = $moduleDir . '/' . $subDir;
-                if (is_dir($dir)) {
-                    $classes += ClassMapGenerator::createMap($dir);
-                }
-            }
+            $classes += ClassMapGenerator::createMap($moduleDir);
         }
 
         return $classes;
@@ -173,6 +167,15 @@ final class AttributeCompiler
                     $className,
                     $method->getName(),
                     $e->getMessage(),
+                ));
+                continue;
+            }
+
+            if ($cronJob->schedule === null && $cronJob->configPath === null) {
+                $io->writeError(sprintf(
+                    '  <warning>CronJob on %s::%s has neither schedule nor config_path, skipping</warning>',
+                    $className,
+                    $method->getName(),
                 ));
                 continue;
             }
@@ -276,13 +279,16 @@ final class AttributeCompiler
         return $className;
     }
 
-    private static function writeOutput(string $outputDir): void
+    private static function writeOutput(string $outputDir, IOInterface $io): void
     {
-        if (!is_dir($outputDir)) {
-            mkdir($outputDir, 0755, true);
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0755, true)) {
+            $io->writeError(sprintf('  <error>Failed to create directory %s</error>', $outputDir));
+            return;
         }
 
         $content = '<?php return ' . var_export(self::$data, true) . ";\n";
-        file_put_contents($outputDir . '/attributes.php', $content);
+        if (file_put_contents($outputDir . '/attributes.php', $content) === false) {
+            $io->writeError(sprintf('  <error>Failed to write %s/attributes.php</error>', $outputDir));
+        }
     }
 }

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -76,7 +76,13 @@ final class AttributeCompiler
     }
 
     /**
-     * Scan all module directories for PHP classes using Composer's ClassMapGenerator.
+     * Scan module directories for PHP classes using Composer's ClassMapGenerator.
+     *
+     * Only scans app/code/{pool}/{Namespace}/{Module}/ directories.
+     * Classes in lib/ or other non-standard locations are not included.
+     *
+     * Later packages overwrite earlier ones so that local code pool
+     * overrides take precedence over core/community classes.
      *
      * @return array<class-string, string>
      */
@@ -85,7 +91,9 @@ final class AttributeCompiler
         $classes = [];
 
         foreach (AutoloadRuntime::globPackages('/app/code/*/*/*', GLOB_ONLYDIR) as $moduleDir) {
-            $classes += ClassMapGenerator::createMap($moduleDir);
+            foreach (ClassMapGenerator::createMap($moduleDir) as $class => $file) {
+                $classes[$class] = $file;
+            }
         }
 
         return $classes;
@@ -139,6 +147,19 @@ final class AttributeCompiler
                 }
 
                 self::$data['observers'][$area][$event] ??= [];
+
+                foreach (self::$data['observers'][$area][$event] as $existing) {
+                    if ($existing['name'] === $name) {
+                        $io->writeError(sprintf(
+                            '  <warning>Duplicate observer name "%s" on %s/%s</warning>',
+                            $name,
+                            $area,
+                            $event,
+                        ));
+                        break;
+                    }
+                }
+
                 self::$data['observers'][$area][$event][] = $entry;
 
                 if ($observer->replaces !== null) {
@@ -181,6 +202,17 @@ final class AttributeCompiler
             }
 
             $name = $cronJob->name ?? self::generateCronJobName($className, $method->getName());
+
+            if (isset(self::$data['crontab'][$name])) {
+                $io->writeError(sprintf(
+                    '  <warning>CronJob name "%s" on %s::%s overwrites %s::%s</warning>',
+                    $name,
+                    $className,
+                    $method->getName(),
+                    self::$data['crontab'][$name]['class'],
+                    self::$data['crontab'][$name]['method'],
+                ));
+            }
 
             self::$data['crontab'][$name] = [
                 'class' => $className,

--- a/src/AutoloadPlugin.php
+++ b/src/AutoloadPlugin.php
@@ -66,6 +66,7 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
     {
         return [
             ScriptEvents::PRE_AUTOLOAD_DUMP => 'onPreAutoloadDumpCmd',
+            ScriptEvents::POST_AUTOLOAD_DUMP => 'onPostAutoloadDumpCmd',
         ];
     }
 
@@ -110,5 +111,22 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
 
         $rootPackage->setAutoload($autoloadDefinition);
         $rootPackage->setIncludePaths([...$includePaths, ...$rootPackage->getIncludePaths()]);
+    }
+
+    public function onPostAutoloadDumpCmd(Event $event): void
+    {
+        $rootDir = dirname($this->composer->getConfig()->get('vendor-dir'));
+
+        // Require the fresh autoloader so all classes are available for reflection
+        require $rootDir . '/vendor/autoload.php';
+
+        if (!class_exists(\Maho\Attributes\Observer::class)) {
+            return;
+        }
+
+        $outputDir = $rootDir . '/var/compiled';
+        $event->getIO()->write('<info>Maho: Compiling PHP attributes...</info>');
+        AttributeCompiler::compile($outputDir);
+        $event->getIO()->write('<info>Maho: PHP attributes compiled successfully.</info>');
     }
 }

--- a/src/AutoloadPlugin.php
+++ b/src/AutoloadPlugin.php
@@ -117,7 +117,9 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
     {
         $rootDir = dirname($this->composer->getConfig()->get('vendor-dir'));
 
-        // Require the fresh autoloader so all classes are available for reflection
+        // Load the freshly-generated autoloader so that module classes are available
+        // for reflection during attribute compilation. This runs in POST_AUTOLOAD_DUMP,
+        // after Composer has finished writing the autoloader, so re-registration is safe.
         require_once $rootDir . '/vendor/autoload.php';
 
         if (!class_exists(\Maho\Attributes\Observer::class)) {

--- a/src/AutoloadPlugin.php
+++ b/src/AutoloadPlugin.php
@@ -126,7 +126,7 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
 
         $outputDir = $rootDir . '/var/compiled';
         $event->getIO()->write('<info>Maho: Compiling PHP attributes...</info>');
-        AttributeCompiler::compile($outputDir);
+        AttributeCompiler::compile($outputDir, $event->getIO());
         $event->getIO()->write('<info>Maho: PHP attributes compiled successfully.</info>');
     }
 }

--- a/src/AutoloadPlugin.php
+++ b/src/AutoloadPlugin.php
@@ -118,7 +118,7 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
         $rootDir = dirname($this->composer->getConfig()->get('vendor-dir'));
 
         // Require the fresh autoloader so all classes are available for reflection
-        require $rootDir . '/vendor/autoload.php';
+        require_once $rootDir . '/vendor/autoload.php';
 
         if (!class_exists(\Maho\Attributes\Observer::class)) {
             return;

--- a/stubs/MahoAttributes.stub
+++ b/stubs/MahoAttributes.stub
@@ -1,0 +1,32 @@
+<?php
+
+// TODO: Remove these stubs once the attribute classes are merged into mahocommerce/maho
+// and the package is added as a require-dev dependency (see https://github.com/MahoCommerce/maho/issues/781)
+
+namespace Maho\Attributes;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Observer
+{
+    public function __construct(
+        public string $event,
+        public string $area = 'global',
+        public ?string $name = null,
+        public string $type = 'singleton',
+        public ?string $replaces = null,
+        /** @var array<string, mixed> */
+        public array $args = [],
+    ) {
+    }
+}
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class CronJob
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $schedule = null,
+        public ?string $configPath = null,
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AttributeCompiler` class that scans all Maho packages for `#[Observer]` and `#[CronJob]` PHP attributes using Reflection
- Hooks into `POST_AUTOLOAD_DUMP` to compile attributes into `var/compiled/attributes.php` after every `composer dump-autoload`
- The compiled output is a plain PHP array with observer and cron job definitions, including module names for dependency-based ordering at runtime

## Test plan

- Run `composer dump-autoload` and verify `var/compiled/attributes.php` is generated
- Add a test `#[Observer]` or `#[CronJob]` attribute to a module class, recompile, verify it appears in the output
- Verify the compiled file is empty when no attributes are used

Related: MahoCommerce/maho#781