### PR TITLE
Write compiled attributes to vendor/composer/

### DIFF
--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -369,14 +369,9 @@ final class AttributeCompiler
 
     private static function writeOutput(string $outputDir, IOInterface $io): void
     {
-        if (!is_dir($outputDir) && !mkdir($outputDir, 0755, true)) {
-            $io->writeError(sprintf('  <error>Failed to create directory %s</error>', $outputDir));
-            return;
-        }
-
         $content = '<?php return ' . var_export(self::$data, true) . ";\n";
-        if (file_put_contents($outputDir . '/attributes.php', $content) === false) {
-            $io->writeError(sprintf('  <error>Failed to write %s/attributes.php</error>', $outputDir));
+        if (file_put_contents($outputDir . '/maho_attributes.php', $content) === false) {
+            $io->writeError(sprintf('  <error>Failed to write %s/maho_attributes.php</error>', $outputDir));
         }
     }
 }

--- a/src/AutoloadPlugin.php
+++ b/src/AutoloadPlugin.php
@@ -157,7 +157,7 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
                 return;
             }
 
-            $outputDir = $rootDir . '/var/compiled';
+            $outputDir = $rootDir . '/vendor/composer';
             $event->getIO()->write('<info>Maho: Compiling PHP attributes...</info>');
             AttributeCompiler::compile($outputDir, $event->getIO());
             $event->getIO()->write('<info>Maho: PHP attributes compiled successfully.</info>');


### PR DESCRIPTION
## Summary

- Write `maho_attributes.php` to `vendor/composer/` instead of `var/compiled/`
- Remove directory creation logic since `vendor/composer/` always exists

This prevents accidental deletion when clearing `var/` (a common troubleshooting step in Maho/Magento). The file is generated at `composer dump-autoload` time, so it belongs alongside other composer-generated files like `autoload_classmap.php`.

Companion change in maho: MahoCommerce/maho#811

## Test plan

- [ ] `composer dump-autoload` writes `vendor/composer/maho_attributes.php`
- [ ] `var/compiled/attributes.php` is no longer created
- [ ] Clearing `var/` does not break attribute-based observers/cron