### PR TITLE
Rename Maho\Attributes namespace to Maho\Config

### DIFF
--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -4,8 +4,8 @@ namespace Maho\ComposerPlugin;
 
 use Composer\ClassMapGenerator\ClassMapGenerator;
 use Composer\IO\IOInterface;
-use Maho\Attributes\CronJob;
-use Maho\Attributes\Observer;
+use Maho\Config\CronJob;
+use Maho\Config\Observer;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -57,7 +57,7 @@ final class AttributeCompiler
                 continue;
             }
 
-            if (strpos($contents, 'Maho\Attributes\Observer') === false && strpos($contents, 'Maho\Attributes\CronJob') === false) {
+            if (strpos($contents, 'Maho\Config\Observer') === false && strpos($contents, 'Maho\Config\CronJob') === false) {
                 continue;
             }
 

--- a/src/AutoloadPlugin.php
+++ b/src/AutoloadPlugin.php
@@ -123,7 +123,7 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
         $includePaths = AutoloadRuntime::generateIncludePaths();
         $packages = AutoloadRuntime::getInstalledPackages();
         $autoloader = function (string $class) use ($rootDir, $includePaths, $packages): void {
-            // Maho namespace classes from lib/ (e.g. Maho\Attributes\Observer)
+            // Maho namespace classes from lib/ (e.g. Maho\Config\Observer)
             if (str_starts_with($class, 'Maho\\')) {
                 $relative = str_replace('\\', '/', $class) . '.php';
                 $file = $rootDir . '/lib/' . $relative;
@@ -153,7 +153,7 @@ final class AutoloadPlugin implements PluginInterface, EventSubscriberInterface
         spl_autoload_register($autoloader);
 
         try {
-            if (!class_exists(\Maho\Attributes\Observer::class)) {
+            if (!class_exists(\Maho\Config\Observer::class)) {
                 return;
             }
 

--- a/stubs/MahoAttributes.stub
+++ b/stubs/MahoAttributes.stub
@@ -3,7 +3,7 @@
 // TODO: Remove these stubs once the attribute classes are merged into mahocommerce/maho
 // and the package is added as a require-dev dependency (see https://github.com/MahoCommerce/maho/issues/781)
 
-namespace Maho\Attributes;
+namespace Maho\Config;
 
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Observer


### PR DESCRIPTION
## Summary

- Renames `Maho\Attributes\Observer` and `Maho\Attributes\CronJob` to `Maho\Config\Observer` and `Maho\Config\CronJob`
- Updates fast-path string check, use imports, autoloader class existence check, and stubs

## Context

Companion to MahoCommerce/maho#811 — the `Maho\Config` namespace better communicates that these attributes register things in the Maho config system.