### PR TITLE
Use class alias for observer names and flexible replaces matching

### DIFF
--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -298,8 +298,7 @@ final class AttributeCompiler
      * - Exact name (e.g. 'my_observer')
      * - Alias format (e.g. 'catalog/observer::myMethod')
      * - Class name format (e.g. 'Mage_Catalog_Model_Observer::myMethod')
-     */
-    /**
+     *
      * @param array{name: string, module: string, class: string, alias: string, method: string, type: string, args: array<string, mixed>} $observer
      */
     private static function observerMatchesTarget(array $observer, string $target): bool

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -21,7 +21,7 @@ final class AttributeCompiler
 
     /**
      * @var array{
-     *     observers: array<string, array<string, list<array{name: string, module: string, alias: string, method: string, type: string, args: array<string, mixed>}>>>,
+     *     observers: array<string, array<string, list<array{name: string, module: string, class: string, alias: string, method: string, type: string, args: array<string, mixed>}>>>,
      *     crontab: array<string, array{alias: string, method: string, schedule: ?string, config_path: ?string}>,
      *     replaces?: array<string, array<string, list<array{target: string}>>>
      * }
@@ -133,6 +133,7 @@ final class AttributeCompiler
             $entry = [
                 'name' => $name,
                 'module' => self::extractModuleName($className),
+                'class' => $className,
                 'alias' => $alias,
                 'method' => $method->getName(),
                 'type' => $observer->type,
@@ -304,10 +305,14 @@ final class AttributeCompiler
             return true;
         }
 
-        // If target contains '::', try matching against alias::method and class::method
         if (str_contains($target, '::')) {
             $aliasBasedName = $observer['alias'] . '::' . $observer['method'];
             if ($aliasBasedName === $target) {
+                return true;
+            }
+
+            $classBasedName = $observer['class'] . '::' . $observer['method'];
+            if ($classBasedName === $target) {
                 return true;
             }
         }
@@ -351,7 +356,7 @@ final class AttributeCompiler
         foreach (self::$classAliasMap as $prefix => $group) {
             if (str_starts_with($className, $prefix . '_')) {
                 $suffix = substr($className, strlen($prefix) + 1);
-                return $group . '/' . $suffix;
+                return $group . '/' . strtolower($suffix);
             }
         }
         return null;

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -307,7 +307,7 @@ final class AttributeCompiler
 
         if (str_contains($target, '::')) {
             $aliasBasedName = $observer['alias'] . '::' . $observer['method'];
-            if (strcasecmp($aliasBasedName, $target) === 0) {
+            if ($aliasBasedName === $target) {
                 return true;
             }
 
@@ -348,7 +348,7 @@ final class AttributeCompiler
     }
 
     /**
-     * Resolve a FQCN to a Maho class alias (e.g. 'Mage_Newsletter_Model_Observer' => 'newsletter/Observer').
+     * Resolve a FQCN to a Maho class alias (e.g. 'Mage_Newsletter_Model_Observer' => 'newsletter/observer').
      * Returns null if no matching alias is found.
      */
     private static function resolveClassAlias(string $className): ?string
@@ -356,7 +356,7 @@ final class AttributeCompiler
         foreach (self::$classAliasMap as $prefix => $group) {
             if (str_starts_with($className, $prefix . '_')) {
                 $suffix = substr($className, strlen($prefix) + 1);
-                return $group . '/' . $suffix;
+                return $group . '/' . strtolower($suffix);
             }
         }
         return null;

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -125,14 +125,15 @@ final class AttributeCompiler
                 continue;
             }
 
-            $name = $observer->name ?? $className . '::' . $method->getName();
+            $alias = self::resolveClassAlias($className) ?? $className;
+            $name = $observer->name ?? $alias . '::' . $method->getName();
             $areas = array_map('trim', explode(',', $observer->area));
             $event = strtolower($observer->event);
 
             $entry = [
                 'name' => $name,
                 'module' => self::extractModuleName($className),
-                'alias' => self::resolveClassAlias($className) ?? $className,
+                'alias' => $alias,
                 'method' => $method->getName(),
                 'type' => $observer->type,
                 'args' => $observer->args,
@@ -267,7 +268,7 @@ final class AttributeCompiler
                 $observers = array_values(
                     array_filter(
                         $observers,
-                        static fn (array $observer): bool => $observer['name'] !== $target,
+                        static fn (array $observer): bool => !self::observerMatchesTarget($observer, $target),
                     ),
                 );
                 self::$data['observers'][$area][$event] = $observers;
@@ -287,6 +288,31 @@ final class AttributeCompiler
             }
             self::$data['replaces'] = $indexed;
         }
+    }
+
+    /**
+     * Check if an observer matches a replaces target.
+     *
+     * Supports matching by:
+     * - Exact name (e.g. 'my_observer')
+     * - Alias format (e.g. 'catalog/observer::myMethod')
+     * - Class name format (e.g. 'Mage_Catalog_Model_Observer::myMethod')
+     */
+    private static function observerMatchesTarget(array $observer, string $target): bool
+    {
+        if ($observer['name'] === $target) {
+            return true;
+        }
+
+        // If target contains '::', try matching against alias::method and class::method
+        if (str_contains($target, '::')) {
+            $aliasBasedName = $observer['alias'] . '::' . $observer['method'];
+            if ($aliasBasedName === $target) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -299,6 +299,9 @@ final class AttributeCompiler
      * - Alias format (e.g. 'catalog/observer::myMethod')
      * - Class name format (e.g. 'Mage_Catalog_Model_Observer::myMethod')
      */
+    /**
+     * @param array{name: string, module: string, class: string, alias: string, method: string, type: string, args: array<string, mixed>} $observer
+     */
     private static function observerMatchesTarget(array $observer, string $target): bool
     {
         if ($observer['name'] === $target) {

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -340,7 +340,7 @@ final class AttributeCompiler
                 foreach ($xml->global->{$groupType}->children() as $groupName => $groupConfig) {
                     $classPrefix = (string) $groupConfig->class;
                     if ($classPrefix !== '') {
-                        self::$classAliasMap[$classPrefix] = $groupName;
+                        self::$classAliasMap[$classPrefix] = strtolower($groupName);
                     }
                 }
             }

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -356,7 +356,9 @@ final class AttributeCompiler
         foreach (self::$classAliasMap as $prefix => $group) {
             if (str_starts_with($className, $prefix . '_')) {
                 $suffix = substr($className, strlen($prefix) + 1);
-                return $group . '/' . strtolower($suffix);
+                $parts = explode('_', $suffix);
+                $alias = implode('_', array_map('lcfirst', $parts));
+                return $group . '/' . $alias;
             }
         }
         return null;

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -307,7 +307,7 @@ final class AttributeCompiler
 
         if (str_contains($target, '::')) {
             $aliasBasedName = $observer['alias'] . '::' . $observer['method'];
-            if ($aliasBasedName === $target) {
+            if (strcasecmp($aliasBasedName, $target) === 0) {
                 return true;
             }
 
@@ -348,7 +348,7 @@ final class AttributeCompiler
     }
 
     /**
-     * Resolve a FQCN to a Maho class alias (e.g. 'Mage_Newsletter_Model_Observer' => 'newsletter/observer').
+     * Resolve a FQCN to a Maho class alias (e.g. 'Mage_Newsletter_Model_Observer' => 'newsletter/Observer').
      * Returns null if no matching alias is found.
      */
     private static function resolveClassAlias(string $className): ?string
@@ -356,7 +356,7 @@ final class AttributeCompiler
         foreach (self::$classAliasMap as $prefix => $group) {
             if (str_starts_with($className, $prefix . '_')) {
                 $suffix = substr($className, strlen($prefix) + 1);
-                return $group . '/' . strtolower($suffix);
+                return $group . '/' . $suffix;
             }
         }
         return null;


### PR DESCRIPTION
## Summary

- Auto-generated observer names now use the class alias instead of FQCN (e.g. catalog/observer::myMethod instead of Mage_Catalog_Model_Observer::myMethod), consistent with how aliases are used elsewhere
- The replaces directive now matches against both the observer name and its alias::method format, so users can target observers using either the class name or alias

## Test plan

- Run composer dump-autoload and verify vendor/composer/maho_attributes.php has alias-based auto-generated names
- Test that replaces works with explicit names, alias format, and class name format