### PR TITLE
Fix config.xml glob pattern (buildClassAliasMap and buildFrontNameMap were always empty)

### DIFF
--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -463,7 +463,7 @@ final class AttributeCompiler
     {
         self::$classAliasMap = [];
 
-        foreach (AutoloadRuntime::globPackages('/app/code/*/*/etc/config.xml') as $configFile) {
+        foreach (AutoloadRuntime::globPackages('/app/code/*/*/*/etc/config.xml') as $configFile) {
             $xml = @simplexml_load_file($configFile);
             if ($xml === false) {
                 $io->writeError(sprintf('  <warning>Failed to parse %s, skipping alias resolution for this module</warning>', $configFile));
@@ -494,7 +494,7 @@ final class AttributeCompiler
         self::$adminFrontName = 'admin';
         self::$installFrontName = 'install';
 
-        foreach (AutoloadRuntime::globPackages('/app/code/*/*/etc/config.xml') as $configFile) {
+        foreach (AutoloadRuntime::globPackages('/app/code/*/*/*/etc/config.xml') as $configFile) {
             $xml = @simplexml_load_file($configFile);
             if ($xml === false) {
                 $io->writeError(sprintf('  <warning>Failed to parse %s, skipping frontName resolution for this module</warning>', $configFile));
@@ -573,11 +573,13 @@ final class AttributeCompiler
             };
 
             if ($frontName === null) {
-                $io->writeError(sprintf(
-                    '  <warning>No frontName found for module "%s", skipping reverse lookup for route "%s"</warning>',
-                    $route['module'],
-                    $routeName,
-                ));
+                if ($io->isVerbose()) {
+                    $io->writeError(sprintf(
+                        '  <warning>No frontName found for module "%s", skipping reverse lookup for route "%s"</warning>',
+                        $route['module'],
+                        $routeName,
+                    ));
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Both `buildClassAliasMap` and `buildFrontNameMap` used `/app/code/*/*/etc/config.xml` (2 wildcards) but Magento's module structure needs 3: `app/code/{pool}/{Namespace}/{Module}/etc/config.xml`
- This meant both maps were always empty: observer aliases never resolved, route reverse lookup never populated
- Downgrade "no frontName" log to verbose-only — PSR-4 modules without a config.xml router entry are expected to have no frontName

## Root cause

The glob was silently matching nothing, so `buildClassAliasMap` and `buildFrontNameMap` built empty maps on every run. The flood of "No frontName found" warnings after 4.0.12 exposed this pre-existing bug.