### PR TITLE
Dump pre-compiled Symfony UrlMatcher and UrlGenerator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,19 @@
     "license": "MIT",
     "require": {
         "composer-plugin-api": "^2.1",
-        "composer-runtime-api": "^2"
+        "composer-runtime-api": "^2",
+        "symfony/routing": "^7.4"
+    },
+    "replace": {
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-mbstring": "*",
+        "symfony/polyfill-intl-grapheme": "*",
+        "symfony/polyfill-intl-idn": "*",
+        "symfony/polyfill-intl-normalizer": "*",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*",
+        "symfony/polyfill-php83": "*"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,161 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "275f6a04322639d4733e91327eb4d5ce",
-    "packages": [],
+    "content-hash": "227c770fd2819d261480e557a5893184",
+    "packages": [
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b",
+                "reference": "9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/config": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Maps an HTTP request to a set of configuration variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/routing/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
@@ -778,11 +931,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.47",
+            "version": "2.1.50",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/79015445d8bd79e62b29140f12e5bfced1dcca65",
-                "reference": "79015445d8bd79e62b29140f12e5bfced1dcca65",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
+                "reference": "d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
                 "shasum": ""
             },
             "require": {
@@ -827,7 +980,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-13T15:49:08+00:00"
+            "time": "2026-04-17T13:10:32+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -1370,73 +1523,6 @@
             "time": "2026-03-30T15:14:47+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
             "name": "symfony/filesystem",
             "version": "v8.0.8",
             "source": {
@@ -1575,343 +1661,8 @@
             "time": "2026-03-30T15:14:47+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.35.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.35.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.35.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.35.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.35.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.35.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.35.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.35.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T17:25:58+00:00"
-        },
-        {
             "name": "symfony/polyfill-php73",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -1967,171 +1718,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.35.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.35.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.35.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.35.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -2155,7 +1742,7 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
@@ -2211,7 +1798,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
             },
             "funding": [
                 {

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -608,6 +608,22 @@ final class AttributeCompiler
     }
 
     /**
+     * Resolve the frontName key used in both the reverseLookup/controllerLookup maps
+     * and the `_maho_front_name` route default. Admin/install use sentinels because
+     * their runtime frontName can differ from the compile-time one (use_custom_admin_path).
+     *
+     * @param array{area: string, path: string} $route
+     */
+    private static function resolveFrontNameKey(array $route): string
+    {
+        return match ($route['area']) {
+            'adminhtml' => self::ADMIN_SENTINEL,
+            'install' => self::INSTALL_SENTINEL,
+            default => explode('/', ltrim($route['path'], '/'))[0],
+        };
+    }
+
+    /**
      * Build reverse-lookup maps keyed by frontName.
      *
      * - `reverseLookup`: frontName/controller/action → routeName (used by URL generation)
@@ -616,9 +632,6 @@ final class AttributeCompiler
      * Admin and install routes are keyed by a sentinel rather than the config.xml frontName,
      * because the runtime admin frontName is configurable via `use_custom_admin_path`.
      * The runtime translates the incoming frontName to the sentinel before lookup.
-     *
-     * For PSR-4 modules, extractModuleName() returns 'Vendor\Module' while config.xml <args><module>
-     * typically uses 'Vendor_Module'. Both formats are tried so either convention works.
      */
     private static function buildReverseLookup(IOInterface $io): void
     {
@@ -626,14 +639,7 @@ final class AttributeCompiler
         $controllerLookup = [];
 
         foreach (self::$data['routes'] as $routeName => $route) {
-            // Frontend frontName is the first segment of the route path (e.g. '/catalog/...').
-            // Admin and install use sentinels because their runtime frontName can differ
-            // from the compile-time one (use_custom_admin_path).
-            $frontName = match ($route['area']) {
-                'adminhtml' => self::ADMIN_SENTINEL,
-                'install' => self::INSTALL_SENTINEL,
-                default => explode('/', ltrim($route['path'], '/'))[0],
-            };
+            $frontName = self::resolveFrontNameKey($route);
 
             if ($frontName === '') {
                 if ($io->isVerbose()) {
@@ -784,23 +790,13 @@ final class AttributeCompiler
             $path = $route['path'];
             $requirements = $route['requirements'];
 
-            // _maho_front_name is baked into defaults for runtime use (module/route name).
-            // Admin and install use sentinels because Symfony does not expand placeholders
-            // into default values — the literal string "{_adminFrontName}" would otherwise
-            // leak through. Frontend uses the first path segment.
-            $frontName = match ($route['area']) {
-                'adminhtml' => self::ADMIN_SENTINEL,
-                'install' => self::INSTALL_SENTINEL,
-                default => explode('/', ltrim($route['path'], '/'))[0],
-            };
-
             $defaults = array_merge($route['defaults'], [
                 '_maho_controller' => $route['class'],
                 '_maho_action' => $route['action'],
                 '_maho_area' => $route['area'],
                 '_maho_module' => $route['module'],
                 '_maho_controller_name' => $route['controllerName'],
-                '_maho_front_name' => $frontName,
+                '_maho_front_name' => self::resolveFrontNameKey($route),
             ]);
 
             if ($route['area'] === 'adminhtml') {

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -9,6 +9,10 @@ use Maho\Config\Observer;
 use Maho\Config\Route;
 use ReflectionClass;
 use ReflectionMethod;
+use Symfony\Component\Routing\Generator\Dumper\CompiledUrlGeneratorDumper;
+use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
+use Symfony\Component\Routing\Route as SymfonyRoute;
+use Symfony\Component\Routing\RouteCollection;
 
 final class AttributeCompiler
 {
@@ -28,19 +32,18 @@ final class AttributeCompiler
      */
     private static array $classAliasMap = [];
 
+
     /**
-     * Map of module name → frontend frontName, built from config.xml router config.
-     * e.g. 'Mage_Checkout' => 'checkout'
-     *
-     * @var array<string, string>
+     * Sentinel key for admin area in reverseLookup / controllerLookup.
+     * Admin frontName is runtime-configurable (use_custom_admin_path), so routes are
+     * keyed by this sentinel in compiled lookup maps and translated at dispatch time.
      */
-    private static array $frontNameMap = [];
+    public const ADMIN_SENTINEL = '__admin__';
 
-    /** Admin area frontName (typically 'admin'), detected from config.xml. */
-    private static string $adminFrontName = 'admin';
-
-    /** Install area frontName (typically 'install'), detected from config.xml. */
-    private static string $installFrontName = 'install';
+    /**
+     * Sentinel key for install area in reverseLookup / controllerLookup.
+     */
+    public const INSTALL_SENTINEL = '__install__';
 
     /**
      * @var array{
@@ -48,7 +51,8 @@ final class AttributeCompiler
      *     crontab: array<string, array{module: string, alias: string, method: string, schedule: ?string, config_path: ?string}>,
      *     routes: array<string, array{path: string, class: string, action: string, methods: list<string>, defaults: array<string, mixed>, requirements: array<string, string>, area: string, module: string, controllerName: string, pathVariables: list<string>}>,
      *     replaces?: array<string, array<string, list<array{target: string}>>>,
-     *     reverseLookup: array<string, string>
+     *     reverseLookup: array<string, string>,
+     *     controllerLookup: array<string, string>
      * }
      */
     private static array $data;
@@ -65,6 +69,7 @@ final class AttributeCompiler
             'crontab' => [],
             'routes' => [],
             'reverseLookup' => [],
+            'controllerLookup' => [],
         ];
 
         $replaces = [];
@@ -125,6 +130,7 @@ final class AttributeCompiler
         self::applyReplaces($replaces);
         self::buildReverseLookup($io);
         self::writeOutput($outputDir, $io);
+        self::dumpRoutingFiles($outputDir, $io);
     }
 
     /**
@@ -320,10 +326,17 @@ final class AttributeCompiler
                 ));
             }
 
-            preg_match_all('/\{(\w+)\}/', $route->path, $pathVarMatches);
+            // Admin paths compile to a placeholder so the runtime admin frontName
+            // (use_custom_admin_path) can be injected without re-dumping the matcher.
+            $path = $route->path;
+            if ($area === 'adminhtml') {
+                $path = (string) preg_replace('#^/admin(/|$)#', '/{_adminFrontName}$1', $path);
+            }
+
+            preg_match_all('/\{(\w+)\}/', $path, $pathVarMatches);
 
             self::$data['routes'][$name] = [
-                'path' => $route->path,
+                'path' => $path,
                 'class' => $className,
                 'action' => $method->getName(),
                 'methods' => $route->methods,
@@ -554,23 +567,12 @@ final class AttributeCompiler
     }
 
     /**
-     * Parse all module config.xml files once and populate both the class alias map
-     * and the frontName maps in a single pass.
-     *
-     * Class aliases: <global><models|helpers|blocks><group><class> → group alias
-     * e.g. 'Mage_Newsletter_Model' => 'newsletter'
-     *
-     * Front names:
-     *   Frontend: <frontend><routers><X><args><module> + <frontName>
-     *   Admin:    <admin|adminhtml><routers><X><args><frontName>
-     *   Install:  <install><routers><X><args><frontName>
+     * Parse <global><models|helpers|blocks><group><class> across all module config.xml files
+     * to build the class-alias map (e.g. 'Mage_Newsletter_Model' => 'newsletter').
      */
     private static function buildConfigMaps(IOInterface $io): void
     {
         self::$classAliasMap = [];
-        self::$frontNameMap = [];
-        self::$adminFrontName = 'admin';
-        self::$installFrontName = 'install';
 
         foreach (AutoloadRuntime::globPackages('/app/code/*/*/*/etc/config.xml') as $configFile) {
             if (self::$activeModules !== null) {
@@ -587,7 +589,6 @@ final class AttributeCompiler
                 continue;
             }
 
-            // Class alias map
             foreach (['models', 'helpers', 'blocks'] as $groupType) {
                 foreach ($xml->global->{$groupType}->children() ?? [] as $groupName => $groupConfig) {
                     $classPrefix = (string) $groupConfig->class;
@@ -596,64 +597,18 @@ final class AttributeCompiler
                     }
                 }
             }
-
-            // Frontend frontName map
-            if (isset($xml->frontend->routers)) {
-                foreach ($xml->frontend->routers->children() ?? [] as $routerConfig) {
-                    $module = (string) ($routerConfig->args->module ?? '');
-                    $frontName = (string) ($routerConfig->args->frontName ?? '');
-                    if ($module !== '' && $frontName !== '') {
-                        self::$frontNameMap[$module] = $frontName;
-                    }
-                }
-            }
-
-            // Admin frontName
-            foreach (['admin', 'adminhtml'] as $adminArea) {
-                if (isset($xml->{$adminArea}->routers)) {
-                    foreach ($xml->{$adminArea}->routers->children() ?? [] as $routerConfig) {
-                        $frontName = (string) ($routerConfig->args->frontName ?? '');
-                        if ($frontName === '') {
-                            continue;
-                        }
-                        if (self::$adminFrontName !== 'admin' && self::$adminFrontName !== $frontName) {
-                            $io->writeError(sprintf(
-                                '  <warning>Conflicting admin frontName: already have "%s", ignoring "%s" from %s</warning>',
-                                self::$adminFrontName,
-                                $frontName,
-                                $configFile,
-                            ));
-                        } else {
-                            self::$adminFrontName = $frontName;
-                        }
-                    }
-                }
-            }
-
-            // Install frontName
-            if (isset($xml->install->routers)) {
-                foreach ($xml->install->routers->children() ?? [] as $routerConfig) {
-                    $frontName = (string) ($routerConfig->args->frontName ?? '');
-                    if ($frontName === '') {
-                        continue;
-                    }
-                    if (self::$installFrontName !== 'install' && self::$installFrontName !== $frontName) {
-                        $io->writeError(sprintf(
-                            '  <warning>Conflicting install frontName: already have "%s", ignoring "%s" from %s</warning>',
-                            self::$installFrontName,
-                            $frontName,
-                            $configFile,
-                        ));
-                    } else {
-                        self::$installFrontName = $frontName;
-                    }
-                }
-            }
         }
     }
 
     /**
-     * Build a reverse lookup map from Magento-style frontName/controller/action keys to route names.
+     * Build reverse-lookup maps keyed by frontName.
+     *
+     * - `reverseLookup`: frontName/controller/action → routeName (used by URL generation)
+     * - `controllerLookup`: frontName/controller → module class prefix (used by forward dispatch)
+     *
+     * Admin and install routes are keyed by a sentinel rather than the config.xml frontName,
+     * because the runtime admin frontName is configurable via `use_custom_admin_path`.
+     * The runtime translates the incoming frontName to the sentinel before lookup.
      *
      * For PSR-4 modules, extractModuleName() returns 'Vendor\Module' while config.xml <args><module>
      * typically uses 'Vendor_Module'. Both formats are tried so either convention works.
@@ -661,21 +616,23 @@ final class AttributeCompiler
     private static function buildReverseLookup(IOInterface $io): void
     {
         $reverseLookup = [];
+        $controllerLookup = [];
 
         foreach (self::$data['routes'] as $routeName => $route) {
+            // Frontend frontName is the first segment of the route path (e.g. '/catalog/...').
+            // Admin and install use sentinels because their runtime frontName can differ
+            // from the compile-time one (use_custom_admin_path).
             $frontName = match ($route['area']) {
-                'adminhtml' => self::$adminFrontName,
-                'install' => self::$installFrontName,
-                default => self::$frontNameMap[$route['module']]
-                    ?? self::$frontNameMap[str_replace('\\', '_', $route['module'])]
-                    ?? null,
+                'adminhtml' => self::ADMIN_SENTINEL,
+                'install' => self::INSTALL_SENTINEL,
+                default => explode('/', ltrim($route['path'], '/'))[0],
             };
 
-            if ($frontName === null) {
+            if ($frontName === '') {
                 if ($io->isVerbose()) {
                     $io->writeError(sprintf(
-                        '  <warning>No frontName found for module "%s", skipping reverse lookup for route "%s"</warning>',
-                        $route['module'],
+                        '  <warning>No frontName derivable from path "%s", skipping reverse lookup for route "%s"</warning>',
+                        $route['path'],
                         $routeName,
                     ));
                 }
@@ -683,11 +640,12 @@ final class AttributeCompiler
             }
 
             $action = strtolower((string) preg_replace('/Action$/', '', $route['action']));
-            $key = $frontName . '/' . $route['controllerName'] . '/' . $action;
-            $reverseLookup[$key] = $routeName;
+            $reverseLookup[$frontName . '/' . $route['controllerName'] . '/' . $action] = $routeName;
+            $controllerLookup[$frontName . '/' . $route['controllerName']] = $route['module'];
         }
 
         self::$data['reverseLookup'] = $reverseLookup;
+        self::$data['controllerLookup'] = $controllerLookup;
     }
 
     /**
@@ -796,6 +754,59 @@ final class AttributeCompiler
         $content = '<?php return ' . var_export(self::$data, true) . ";\n";
         if (file_put_contents($outputDir . '/maho_attributes.php', $content) === false) {
             $io->writeError(sprintf('  <error>Failed to write %s/maho_attributes.php</error>', $outputDir));
+        }
+    }
+
+    /**
+     * Build a Symfony RouteCollection from compiled routes and dump pre-compiled
+     * matcher/generator arrays. The dumped files are plain PHP arrays, fully opcached,
+     * so URL matching and generation do no RouteCollection construction at runtime.
+     *
+     * Admin routes carry an `{_adminFrontName}` placeholder with a `/{_catchall}`
+     * suffix for the key/value param convention (e.g. /admin/foo/bar/id/5/store/1).
+     */
+    private static function dumpRoutingFiles(string $outputDir, IOInterface $io): void
+    {
+        $collection = new RouteCollection();
+
+        foreach (self::$data['routes'] as $name => $route) {
+            $path = $route['path'];
+            $requirements = $route['requirements'];
+
+            // Frontend frontName is the first segment of the path; admin/install carry it
+            // via the `{_adminFrontName}` placeholder or the literal `install` segment.
+            $firstSegment = explode('/', ltrim($route['path'], '/'))[0];
+
+            $defaults = array_merge($route['defaults'], [
+                '_maho_controller' => $route['class'],
+                '_maho_action' => $route['action'],
+                '_maho_area' => $route['area'],
+                '_maho_module' => $route['module'],
+                '_maho_controller_name' => $route['controllerName'],
+                '_maho_front_name' => $firstSegment,
+            ]);
+
+            if ($route['area'] === 'adminhtml') {
+                $path = rtrim($path, '/') . '/{_catchall}';
+                $defaults['_catchall'] = '';
+                $requirements['_catchall'] = '.*';
+            }
+
+            $symfonyRoute = new SymfonyRoute($path, $defaults, $requirements);
+            if ($route['methods'] !== []) {
+                $symfonyRoute->setMethods($route['methods']);
+            }
+            $collection->add($name, $symfonyRoute);
+        }
+
+        $matcherDumper = new CompiledUrlMatcherDumper($collection);
+        if (file_put_contents($outputDir . '/maho_url_matcher.php', $matcherDumper->dump()) === false) {
+            $io->writeError(sprintf('  <error>Failed to write %s/maho_url_matcher.php</error>', $outputDir));
+        }
+
+        $generatorDumper = new CompiledUrlGeneratorDumper($collection);
+        if (file_put_contents($outputDir . '/maho_url_generator.php', $generatorDumper->dump()) === false) {
+            $io->writeError(sprintf('  <error>Failed to write %s/maho_url_generator.php</error>', $outputDir));
         }
     }
 }

--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -32,7 +32,6 @@ final class AttributeCompiler
      */
     private static array $classAliasMap = [];
 
-
     /**
      * Sentinel key for admin area in reverseLookup / controllerLookup.
      * Admin frontName is runtime-configurable (use_custom_admin_path), so routes are
@@ -326,11 +325,19 @@ final class AttributeCompiler
                 ));
             }
 
-            // Admin paths compile to a placeholder so the runtime admin frontName
-            // (use_custom_admin_path) can be injected without re-dumping the matcher.
+            // Admin paths compile with a `{_adminFrontName}` placeholder so the runtime
+            // admin frontName (use_custom_admin_path) can be injected per request.
+            // - Path starting with /admin: substitute the prefix with the placeholder.
+            // - Any other admin path: prepend the placeholder so third-party modules
+            //   can declare routes like #[Route('/foo', area: 'adminhtml')] without
+            //   needing to include the admin prefix themselves.
             $path = $route->path;
             if ($area === 'adminhtml') {
-                $path = (string) preg_replace('#^/admin(/|$)#', '/{_adminFrontName}$1', $path);
+                if (preg_match('#^/admin(/|$)#', $path) === 1) {
+                    $path = (string) preg_replace('#^/admin(/|$)#', '/{_adminFrontName}$1', $path);
+                } else {
+                    $path = '/{_adminFrontName}' . (str_starts_with($path, '/') ? '' : '/') . $path;
+                }
             }
 
             preg_match_all('/\{(\w+)\}/', $path, $pathVarMatches);
@@ -767,15 +774,25 @@ final class AttributeCompiler
      */
     private static function dumpRoutingFiles(string $outputDir, IOInterface $io): void
     {
+        if (self::$data['routes'] === []) {
+            return;
+        }
+
         $collection = new RouteCollection();
 
         foreach (self::$data['routes'] as $name => $route) {
             $path = $route['path'];
             $requirements = $route['requirements'];
 
-            // Frontend frontName is the first segment of the path; admin/install carry it
-            // via the `{_adminFrontName}` placeholder or the literal `install` segment.
-            $firstSegment = explode('/', ltrim($route['path'], '/'))[0];
+            // _maho_front_name is baked into defaults for runtime use (module/route name).
+            // Admin and install use sentinels because Symfony does not expand placeholders
+            // into default values — the literal string "{_adminFrontName}" would otherwise
+            // leak through. Frontend uses the first path segment.
+            $frontName = match ($route['area']) {
+                'adminhtml' => self::ADMIN_SENTINEL,
+                'install' => self::INSTALL_SENTINEL,
+                default => explode('/', ltrim($route['path'], '/'))[0],
+            };
 
             $defaults = array_merge($route['defaults'], [
                 '_maho_controller' => $route['class'],
@@ -783,7 +800,7 @@ final class AttributeCompiler
                 '_maho_area' => $route['area'],
                 '_maho_module' => $route['module'],
                 '_maho_controller_name' => $route['controllerName'],
-                '_maho_front_name' => $firstSegment,
+                '_maho_front_name' => $frontName,
             ]);
 
             if ($route['area'] === 'adminhtml') {


### PR DESCRIPTION
## Summary

Builds a Symfony `RouteCollection` from compiled `#[Route]` attributes and dumps it via `CompiledUrlMatcherDumper` and `CompiledUrlGeneratorDumper`. The resulting PHP arrays at `vendor/composer/maho_url_matcher.php` and `vendor/composer/maho_url_generator.php` are fully opcached, so the Maho runtime builds no `RouteCollection` per request and URL matching/generation drop to hash-lookup cost.

### Compile-time changes

- Admin paths are rewritten to `/{_adminFrontName}/...` so the runtime admin frontName (`use_custom_admin_path`) can be substituted per request without re-dumping.
- Admin routes in the `RouteCollection` gain a `/{_catchall}` suffix with `requirements[_catchall] = '.*'` and `defaults[_catchall] = ''` — captures the key/value path convention (`/id/5/store/1`) at match time and omits it on generation.
- `_maho_*` metadata (controller class, action, area, module, controllerName, frontName) is baked in as route defaults so it flows through the matcher output into `ControllerDispatcher::dispatch()`.
- `reverseLookup` (frontName/controller/action → routeName) and new `controllerLookup` (frontName/controller → module) maps are keyed by sentinels `__admin__` / `__install__` for admin/install areas. The runtime translates the incoming frontName to the sentinel before lookup.
- Frontend frontName for the lookup keys is derived from the first segment of the route path, since the `<frontend><routers>` XML blocks have been removed from module `config.xml` files.
- `buildConfigMaps` is reduced to just building the class-alias map; the `$frontNameMap` / `$adminFrontName` / `$installFrontName` properties were removed (obsolete with sentinels).

### Dependency

Adds `symfony/routing: ^7.4` to `require`.

## Test plan

- [x] `composer dump-autoload` emits `maho_attributes.php`, `maho_url_matcher.php`, `maho_url_generator.php`
- [x] PHPStan on the plugin passes
- [x] Runtime smoke tests: frontend routes, admin routes, `/men/shirts/` URL rewrite, custom admin frontName via `use_custom_admin_path`