### PR TITLE
Security: pin setup-php to 2.37.1 and update symfony/routing to 7.4.13

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.37.1
         with:
           php-version: latest
 

--- a/.github/workflows/syntax-php.yml
+++ b/.github/workflows/syntax-php.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup PHP
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.37.1
         with:
           php-version: ${{ matrix.php-versions }}
           ini-values: error_reporting=E_ALL, short_open_tag=Off

--- a/composer.lock
+++ b/composer.lock
@@ -79,16 +79,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -140,7 +140,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.9"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -160,7 +160,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Clears all findings reported for this repo by the [org SBOM scan](https://github.com/MahoCommerce/sboms):

- **GHSA-5wxr-w449-57cm** - pins `shivammathur/setup-php` to `2.37.1` in CI workflows.
- **CVE-2026-45065 / GHSA-72xp-p242-47p9 / CVE-2026-48784** - updates `symfony/routing` from 7.4.9 to 7.4.13 (lockfile only, constraint stays `^7.4`).

Note: `composer audit` also reports two newer Symfony advisories not yet in the SBOM scanners' feeds, both in the dev dependency tree (api-platform/phpstan): CVE-2026-48736 (symfony/http-foundation) and CVE-2026-45075 (symfony/http-kernel). Fixing them requires an 8.0→8.1 bump across ~22 Symfony packages, so I left them out of this PR. Happy to do that separately if wanted.