### PR TITLE
Publish API Platform bundle assets on install/update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Each plugin implements `PluginInterface` and `EventSubscriberInterface` from Com
 - Copies static assets from modules to project:
   - `public/`, `skin/`, `js/` folders from all `maho-module` and `magento-module` packages
   - Main Maho `public/` folder and `maho` CLI script
+  - API Platform bundle assets (Swagger UI / ReDoc / GraphiQL) into `public/bundles/apiplatform/`, the equivalent of Symfony's `assets:install`
 - Checks both actual vendor paths and modman symlink paths for module assets
 
 ### Package Resolution Order

--- a/src/FileCopyPlugin.php
+++ b/src/FileCopyPlugin.php
@@ -105,6 +105,13 @@ final class FileCopyPlugin implements PluginInterface, EventSubscriberInterface
                 $this->copyDirectory("$packagePath/js", "$projectDir/public/js", $io);
             }
         }
+
+        // Publish API Platform bundle assets for the Swagger UI / ReDoc / GraphiQL
+        // pages (the equivalent of Symfony's assets:install, which Maho can't run).
+        $apiPlatformAssets = "$vendorDir/api-platform/core/src/Symfony/Bundle/Resources/public";
+        if (is_dir($apiPlatformAssets)) {
+            $this->copyDirectory($apiPlatformAssets, "$projectDir/public/bundles/apiplatform", $io);
+        }
     }
 
     private function copyDirectory(string $src, string $dst, IOInterface $io): void


### PR DESCRIPTION
## What

`FileCopyPlugin` now publishes the API Platform bundle's static assets into `public/bundles/apiplatform/` during the same `POST_INSTALL_CMD` / `POST_UPDATE_CMD` / `POST_CREATE_PROJECT_CMD` pass that already copies module `public/`, `skin/`, and `js/` folders.

## Why

The API Platform Swagger UI / ReDoc / GraphiQL pages (served at `/api/docs` and `/api/graphql`) load their CSS, JS, and fonts from `public/bundles/apiplatform/*`. In a standard Symfony app `php bin/console assets:install` publishes those files; Maho has no console command for it, so the directory never existed in a Maho project and the docs page rendered unstyled with `404`s on every asset.

This was only exposed once `symfony/twig-bundle` + `symfony/asset` are installed (the opt-in Swagger UI dependencies), since without them `/api/docs` serves JSON-LD and never references the assets.

## How

Copy `vendor/api-platform/core/src/Symfony/Bundle/Resources/public` into `public/bundles/apiplatform/` via the existing `copyDirectory()` helper, guarded by `is_dir()` so it's a no-op when `api-platform/core` isn't installed.

## Notes

- Uses copy (consistent with the rest of the plugin) rather than a symlink, so it works on Windows and survives vendor moves.
- `CLAUDE.md`'s FileCopyPlugin asset list updated to match.