### PR TITLE
Skipped the package's top-level tests/ directory when scanning classes

### DIFF
--- a/src/AttributeCompiler.php
+++ b/src/AttributeCompiler.php
@@ -241,14 +241,23 @@ final class AttributeCompiler
 
         $classes = [];
         $directoryIter = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
-        // Skip vendor/, node_modules/, and dotdirs (.git, .idea, etc.) — these never
-        // contain user-authored Maho classes, and recursing into vendor/ from the
-        // project root tries to autoload the plugin's own composer-plugin classes.
+        // The package's own top-level tests/ dir: skipped because test fixtures (controllers,
+        // observers) must never leak into compiled routes/observers/overrides. This bites in a
+        // dev checkout, where the maho-source package path is the whole repo tree (tests/ and
+        // all). Anchored to the package root — not a name match at any depth — so a directory
+        // deeper in the tree that happens to be named "tests" is left alone.
+        $rootTestsDir = rtrim($dir, '/') . '/tests';
+        // Skip vendor/, node_modules/, and dotdirs (.git, .idea, etc.) too — these never
+        // contain compilable Maho classes, and recursing into vendor/ from the project root
+        // tries to autoload the plugin's own composer-plugin classes.
         $filtered = new \RecursiveCallbackFilterIterator(
             $directoryIter,
-            static function (\SplFileInfo $current): bool {
+            static function (\SplFileInfo $current) use ($rootTestsDir): bool {
                 if (!$current->isDir()) {
                     return true;
+                }
+                if ($current->getPathname() === $rootTestsDir) {
+                    return false;
                 }
                 $name = $current->getFilename();
                 return $name !== 'vendor' && $name !== 'node_modules' && !str_starts_with($name, '.');


### PR DESCRIPTION
## Summary

Excludes a package's **top-level** `tests/` directory from the attribute compiler's class scan, alongside `vendor/` and `node_modules/`.

## Why

In a **dev checkout**, the maho-source package's path is the whole repo tree, so `createClassMap()` recursed into `tests/` and swept up test fixtures (`Tests\…`, mock helpers, fixture controllers). For routes/observers/cron this was latent — a fixture only leaked if it carried the relevant attribute. But the new inheritance-based controller-override detection (#45) acts on **any** subclass of a route-owning controller, with no attribute required. So a fixture like:

```php
class Fixture_CartController extends Mage_Checkout_CartController {}
```

under `tests/` was detected as an override and silently repointed `checkout/cart` at the fixture in the compiled `controllerLookup`.

Production installs are unaffected (`/tests` is `export-ignore`d from the dist), but dev checkouts and CI regenerate the compile from the full tree, so the fixture pollution broke real controllers there.

## Fix

Skip the package root's `tests/` directory in `createClassMap()`'s directory filter. The skip is **anchored to the package root** (`$dir/tests`) rather than matching the name `tests` at any depth — so a directory deeper in the tree that happens to be named `tests` is left alone, avoiding a fragile magic-name match. Test classes must never appear in compiled routes/observers/overrides.

Verified against a full Maho dev tree: classes scanned from a `/tests/` path drop from 22 to 0, and `controllerLookup['checkout/cart']` is restored to `Mage_Checkout_CartController`. PHPStan (level 10 strict) green.